### PR TITLE
Bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ### Deprecated
 
+## [ 2024/03/19 - v0.1.8 ]
+
+### Changed
+
+* CHART: Enabled overriding of images to deploy
+* CHART: Set default images to SHA256 instead of tags to improve security
+
 ## [ 2024/03/19 - v0.1.7 ]
 
 ### Changed

--- a/charts/dogkat/Chart.yaml
+++ b/charts/dogkat/Chart.yaml
@@ -2,8 +2,8 @@
 
 apiVersion: v2
 name: dogkat
-version: 0.1.7
-appVersion: 0.1.7
+version: 0.1.8
+appVersion: 0.1.8
 type: application
 maintainers:
   - name: drew-viles

--- a/charts/dogkat/README.md
+++ b/charts/dogkat/README.md
@@ -1,6 +1,6 @@
 # dogkat
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.7](https://img.shields.io/badge/AppVersion-0.1.7-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.8](https://img.shields.io/badge/AppVersion-0.1.8-informational?style=flat-square)
 
 End-2-End testing for GPUs and some core resources
 

--- a/charts/dogkat/README.md
+++ b/charts/dogkat/README.md
@@ -38,7 +38,7 @@ The following table lists the configurable parameters of the chart and the defau
 | core.php.image.repo | string | `"drewviles/php-pdo@sha256"` | The repo to be used |
 | core.php.image.tag | string | `"253465d95c3fa68871c2ccc6c67d4ed5ee500563fbbfee3b54a9544f8025d1d6"` | The tag to be used |
 | core.postgres.image.repo | string | `"postgres@sha256"` | The repo to be used |
-| core.postgres.image.tag | string | `"sha256:49fd8c13fbd0eb92572df9884ca41882a036beac0f12e520274be85e7e7806e9"` | The tag to be used |
+| core.postgres.image.tag | string | `"49fd8c13fbd0eb92572df9884ca41882a036beac0f12e520274be85e7e7806e9"` | The tag to be used |
 | core.postgres.statefulSet.persistentData.enabled | bool | `true` |  |
 | core.postgres.statefulSet.persistentData.storageClassName | string | `"cinder"` |  |
 | gpu.enabled | bool | `false` |  |

--- a/charts/dogkat/values.yaml
+++ b/charts/dogkat/values.yaml
@@ -35,7 +35,7 @@ core:
       # -- The repo to be used
       repo: postgres@sha256
       # -- The tag to be used
-      tag: sha256:49fd8c13fbd0eb92572df9884ca41882a036beac0f12e520274be85e7e7806e9  # 16.2-alpine
+      tag: 49fd8c13fbd0eb92572df9884ca41882a036beac0f12e520274be85e7e7806e9  # 16.2-alpine
     statefulSet:
       persistentData:
         enabled: true

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -17,7 +17,7 @@ limitations under the License.
 package constants
 
 const (
-	Version     = "v0.1.7"
+	Version     = "v0.1.8"
 	ChartName   = "dogkat"
 	ReleaseName = "dogkat-testing"
 	RepoURL     = "https://drewbernetes.github.io/dogkat"


### PR DESCRIPTION
# What's Changed
Bug fix to remove the sha256 from the image tag for postgres

# Why is it required?
Because stuff won't deploy with it there as it needs to be supplied as part of the repository to ensure things deploy for now.
Ideally this needs a better approach but for now it works!

# PR checklist
- [x] Run tests locally
- [x] Updated Chart Version
- [x] Updated App Version
- [ ] Updated Readme
- [x] Updated Changelog
